### PR TITLE
fix (editstore) add lat lng to edit address

### DIFF
--- a/src/merchant/editstore/index.ts
+++ b/src/merchant/editstore/index.ts
@@ -26,6 +26,8 @@ export const MerchantEditStore = new Elysia({ prefix: '/merchant' })
         return { message: 'Merchant not found' };
       }
 
+      const addr = merchant.address;
+
       return {
         id: merchant.id,
         name: merchant.displayName,
@@ -43,11 +45,20 @@ export const MerchantEditStore = new Elysia({ prefix: '/merchant' })
           email: merchant.owner.email,
         },
         address: {
-          line1: merchant.address.line1,
-          line2: merchant.address.line2,
-          city: merchant.address.city,
-          province: merchant.address.province,
-          postalCode: merchant.address.postalCode,
+          line1: addr.line1,
+          line2: addr.line2,
+          city: addr.city,
+          province: addr.province,
+          postalCode: addr.postalCode,
+          // Prisma Decimal -> number (or null)
+          lat:
+            addr.lat !== null && addr.lat !== undefined
+              ? Number(addr.lat)
+              : null,
+          lng:
+            addr.lng !== null && addr.lng !== undefined
+              ? Number(addr.lng)
+              : null,
         },
         storeId: merchant.id,
       };
@@ -116,6 +127,10 @@ export const MerchantEditStore = new Elysia({ prefix: '/merchant' })
           addressUpdate.province = body.address.province;
         if (body.address.postalCode !== undefined)
           addressUpdate.postalCode = body.address.postalCode;
+
+        // new: lat / lng (numbers; Prisma will map to Decimal)
+        if (body.address.lat !== undefined) addressUpdate.lat = body.address.lat;
+        if (body.address.lng !== undefined) addressUpdate.lng = body.address.lng;
       }
 
       const hasMerchantUpdate = Object.keys(merchantUpdate).length > 0;
@@ -153,6 +168,8 @@ export const MerchantEditStore = new Elysia({ prefix: '/merchant' })
           return { updatedMerchant, updatedOwner, updatedAddress };
         });
 
+        const addr = result.updatedAddress;
+
         return {
           id: result.updatedMerchant.id,
           name: result.updatedMerchant.displayName,
@@ -170,11 +187,19 @@ export const MerchantEditStore = new Elysia({ prefix: '/merchant' })
             email: result.updatedOwner.email,
           },
           address: {
-            line1: result.updatedAddress.line1,
-            line2: result.updatedAddress.line2,
-            city: result.updatedAddress.city,
-            province: result.updatedAddress.province,
-            postalCode: result.updatedAddress.postalCode,
+            line1: addr.line1,
+            line2: addr.line2,
+            city: addr.city,
+            province: addr.province,
+            postalCode: addr.postalCode,
+            lat:
+              addr.lat !== null && addr.lat !== undefined
+                ? Number(addr.lat)
+                : null,
+            lng:
+              addr.lng !== null && addr.lng !== undefined
+                ? Number(addr.lng)
+                : null,
           },
           storeId: result.updatedMerchant.id,
         };
@@ -201,6 +226,8 @@ export const MerchantEditStore = new Elysia({ prefix: '/merchant' })
             city: t.Optional(t.String()),
             province: t.Optional(t.String()),
             postalCode: t.Optional(t.String()),
+            lat: t.Optional(t.Number()),   // 👈 new
+            lng: t.Optional(t.Number()),   // 👈 new
           })
         ),
       }),


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add latitude and longitude fields to merchant address endpoints

- Convert Prisma Decimal types to JavaScript numbers for API responses

- Support lat/lng updates in merchant address modification requests

- Include lat/lng in request/response schema validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Merchant Address Data"] -->|"Extract lat/lng"| B["Convert Decimal to Number"]
  B -->|"Include in Response"| C["GET/PUT Address Response"]
  D["Request Body"] -->|"Parse lat/lng"| E["Update Address in DB"]
  E -->|"Return Updated"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add lat/lng support to merchant address API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/merchant/editstore/index.ts

<ul><li>Extract address object to variable for cleaner code and consistent <br>null-checking<br> <li> Add lat/lng conversion from Prisma Decimal to JavaScript number in GET <br>response<br> <li> Add lat/lng conversion from Prisma Decimal to JavaScript number in PUT <br>response<br> <li> Add lat/lng fields to request body schema validation as optional <br>numbers<br> <li> Add lat/lng update logic in PUT handler to accept and persist <br>coordinate changes</ul>


</details>


  </td>
  <td><a href="https://github.com/ZenithGeeks/backend-leftlovers/pull/44/files#diff-2fc65fae53e969f0ffdc7faa843ed7a09eaeb44b0ab762841bff526c1ea7fff2">+37/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

